### PR TITLE
Feat/#10_新規ユーザー登録機能の実装

### DIFF
--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -1,13 +1,24 @@
+'use client';
+
 import Link from 'next/link';
 
+import { useAuth } from '@/hooks/useAuth';
+
 export default function Header() {
+  const { session, signInWithGithub, signOut } = useAuth();
+  console.log(session);
+
   return (
     <header className="mx-auto flex w-full max-w-7xl items-center justify-between p-4">
       <Link href="/">Logo</Link>
-      <div className="flex items-center gap-x-4">
-        <button>ログイン</button>
-        <Link href="/register">新規登録</Link>
-      </div>
+      {session ? (
+        <button onClick={() => void signOut()}>ログアウト</button>
+      ) : (
+        <div className="flex items-center gap-x-4">
+          <button onClick={() => void signInWithGithub()}>ログイン</button>
+          <Link href="/register">新規登録</Link>
+        </div>
+      )}
     </header>
   );
 }

--- a/src/const/index.ts
+++ b/src/const/index.ts
@@ -1,0 +1,1 @@
+export const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL as string;

--- a/src/features/login/GithubLoginButton.tsx
+++ b/src/features/login/GithubLoginButton.tsx
@@ -5,18 +5,14 @@ import { FaGithub } from 'react-icons/fa6';
 import { useAuth } from '@/hooks/useAuth';
 
 export default function GithubLoginButton() {
-  const { signInWithGithub, loading, error } = useAuth();
+  const { signInWithGithub } = useAuth();
   return (
-    <>
-      {error && <p className="text-red-500">{error}</p>}
-      <button
-        className="mx-auto flex w-full max-w-md items-center justify-center gap-x-2 rounded-lg border border-gray-300 px-4 py-3 text-sm font-bold transition-opacity hover:opacity-60 sm:text-base"
-        disabled={loading}
-        onClick={() => void signInWithGithub()}
-      >
-        <FaGithub className="sm:size-5" />
-        GitHub
-      </button>
-    </>
+    <button
+      className="mx-auto flex w-full max-w-md items-center justify-center gap-x-2 rounded-lg border border-gray-300 px-4 py-3 text-sm font-bold transition-opacity hover:opacity-60 sm:text-base"
+      onClick={() => void signInWithGithub()}
+    >
+      <FaGithub className="sm:size-5" />
+      GitHub
+    </button>
   );
 }

--- a/src/hooks/useAuth.tsx
+++ b/src/hooks/useAuth.tsx
@@ -1,6 +1,7 @@
 import { Session } from '@supabase/supabase-js';
 import { useEffect, useState } from 'react';
 
+import { BASE_URL } from '@/const';
 import supabase from '@/lib/supabase';
 
 export const useAuth = () => {
@@ -20,6 +21,9 @@ export const useAuth = () => {
   const signInWithGithub = async () => {
     await supabase.auth.signInWithOAuth({
       provider: 'github',
+      options: {
+        redirectTo: `${BASE_URL}/register/user-setup`,
+      },
     });
   };
 

--- a/src/hooks/useAuth.tsx
+++ b/src/hooks/useAuth.tsx
@@ -1,25 +1,32 @@
-import { useState } from 'react';
+import { Session } from '@supabase/supabase-js';
+import { useEffect, useState } from 'react';
 
 import supabase from '@/lib/supabase';
 
 export const useAuth = () => {
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  const [session, setSession] = useState<Session | null>(null); // ログイン状態を管理
 
-  const signInWithGithub = async () => {
-    setLoading(true);
-    setError(null);
-
-    const { error } = await supabase.auth.signInWithOAuth({
-      provider: 'github',
+  useEffect(() => {
+    // ログイン状態の変化を監視
+    const { data: authData } = supabase.auth.onAuthStateChange((_, session) => {
+      setSession(session);
     });
 
-    if (error) {
-      setError(error.message);
-    }
+    // イベントリスナーの解除
+    return () => authData.subscription.unsubscribe();
+  }, []);
 
-    setLoading(false);
+  // GitHub でログイン
+  const signInWithGithub = async () => {
+    await supabase.auth.signInWithOAuth({
+      provider: 'github',
+    });
   };
 
-  return { signInWithGithub, loading, error };
+  // サインアウト
+  const signOut = async () => {
+    await supabase.auth.signOut();
+  };
+
+  return { session, signInWithGithub, signOut };
 };


### PR DESCRIPTION
### issue
#10 

### 概要
SupabaseのGithub認証を利用したログイン機能を実装

### 補足情報
- [ ] ログイン後にユーザーの各項目入力フォームへ遷移させてユーザー登録完了後にメイン画面へ遷移させる。
- 各項目は以下の通り
   - 名前
   - アバター画像
   - 性別
   - 学習カテゴリ
   - 自己紹介文
   - プライベートモード